### PR TITLE
(SIMP-9780) Puppetsync: Remove Puppet 5, Support 7

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,11 @@
-*.rb eol=lf
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 *.erb eol=lf
 *.pp eol=lf
 *.sh eol=lf
 *.epp eol=lf
+*.rb eol=lf

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -12,10 +12,10 @@
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby    EOL
 # PE 2019.8     6.22     2.5     2022-12 (LTS)
+# PE 2021.Y     7.x      2.7     Quarterly updates
 #
-# https://puppet.com/docs/pe/2018.1/component_versions_in_recent_pe_releases.html
+# https://puppet.com/docs/pe/latest/component_versions_in_recent_pe_releases.html
 # https://puppet.com/misc/puppet-enterprise-lifecycle
-# https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ==============================================================================
 #
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
-# NOTE: This file is managed by puppetsync.  Make sure any changes are
-#       reflected in the control repo.
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 .*.sw?
 .yardoc
 .idea/
@@ -10,6 +14,7 @@ dist
 /.rspec_system
 /.vagrant
 /.bundle
+/.vendor
 /vendor
 /junit
 /log

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 --log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
 --relative
 --no-class_inherits_from_params_class-check

--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
 --format documentation
 --color
 --fail-fast
--I ./spec/rspec_formatters

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --format documentation
 --color
 --fail-fast
+-I ./spec/rspec_formatters

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,2 @@
-* Tue Mar 16 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.0
+* Tue Jun 15 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.0
 - Initial release

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  puppet_version = ENV['PUPPET_VERSION'] || '~> 6.18'
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 6.22'
   major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
   gem 'puppet', puppet_version

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.4.0 < 8.0.0"
+      "version_requirement": ">= 6.18.0 < 8.0.0"
     }
   ],
   "simp": {
@@ -60,7 +60,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.12.0 < 8.0.0"
+      "version_requirement": ">= 6.22.1 < 8.0.0"
     }
   ],
   "pdk-version": "1.18.0",


### PR DESCRIPTION
This patch:

  * Removes Puppet 5 from `metadata.json` and the GHA & GLCI matrix
  * Ensures support for Puppet 7 in `metadata.json`
    * Ensures Pup 7 for module deps stdlib and concat (if present)
  * Updates GLCI and GHA matrix to model Puppet PE using Puppet 6.22.1
  * Bumps Gemfile's simp-rake-helpers and simp-beaker-helpers min vers
  * Removes `.pmtignore` and adds `.pdkignore`

The patch enforces a standardized asset baseline using simp/puppetsync,
and may apply other updates to ensure conformity.

[SIMP-9800] #close
[SIMP-9780] #comment Drop Puppet 5 in pupmod-simp-ds389
[SIMP-9670] #comment update Puppet 6.22.1 in pupmod-simp-ds389
[SIMP-9606] #comment Switch pupmod-simp-ds389 from .pmtignore to .pdkignore
[SIMP-9781] #comment bump Gemfile versions in pupmod-simp-ds389

[SIMP-9800]: https://simp-project.atlassian.net/browse/SIMP-9800
[SIMP-9780]: https://simp-project.atlassian.net/browse/SIMP-9780
[SIMP-9670]: https://simp-project.atlassian.net/browse/SIMP-9670
[SIMP-9606]: https://simp-project.atlassian.net/browse/SIMP-9606
[SIMP-9781]: https://simp-project.atlassian.net/browse/SIMP-9781