### PR TITLE
(SIMP-10378) Alter TLS defaults

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -48,17 +48,3 @@ ds389::instance::general_config:
 ds389::instance::tls::dse_config:
   'cn=config':
     nsslapd-require-secure-binds: 'on'
-  'cn=encryption,cn=config':
-    nsSSL3Ciphers: >-
-      +TLS_AES_256_GCM_SHA384,
-      +TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-      +TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-      +TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,
-      +TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
-      +TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
-      +TLS_DHE_DSS_WITH_AES_256_GCM_SHA384,
-      +TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,
-      +TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,
-      +TLS_RSA_WITH_AES_256_GCM_SHA384,
-      +TLS_RSA_WITH_AES_256_CBC_SHA256
-

--- a/manifests/instance/tls.pp
+++ b/manifests/instance/tls.pp
@@ -72,7 +72,7 @@ define ds389::instance::tls (
         'allowWeakDHParam'              => 'off',
         'nsSSL2'                        => 'off',
         'nsSSL3'                        => 'off',
-        'nsSSLClientAuth'               => 'required',
+        'nsSSLClientAuth'               => 'allowed',
         'nsTLS1'                        => 'on',
         'nsTLSAllowClientRenegotiation' => 'on',
         'sslVersionMax'                 => 'TLS1.2',
@@ -81,7 +81,7 @@ define ds389::instance::tls (
       'cn=config'               => {
         'nsslapd-ssl-check-hostname' => 'on',
         'nsslapd-validate-cert'      => 'on',
-        'nsslapd-minssf'             => 256
+        'nsslapd-minssf'             => 128
       }
     }
 

--- a/spec/defines/instance/tls_spec.rb
+++ b/spec/defines/instance/tls_spec.rb
@@ -154,17 +154,16 @@ describe 'ds389::instance::tls', type: :define do
                   'allowWeakDHParam' => 'off',
                   'nsSSL2' => 'off',
                   'nsSSL3' => 'off',
-                  'nsSSLClientAuth' => 'required',
+                  'nsSSLClientAuth' => 'allowed',
                   'nsTLS1' => 'on',
                   'nsTLSAllowClientRenegotiation' => 'on',
                   'sslVersionMax' => 'TLS1.2',
-                  'sslVersionMin' => 'TLS1.2',
-                  'nsSSL3Ciphers' => %r{AES_256}
+                  'sslVersionMin' => 'TLS1.2'
                 },
                 'cn=config' => {
                   'nsslapd-ssl-check-hostname' => 'on',
                   'nsslapd-validate-cert' => 'on',
-                  'nsslapd-minssf' => 256,
+                  'nsslapd-minssf' => 128,
                   'nsslapd-require-secure-binds' => 'on',
                   'nsslapd-security' => 'on',
                   'nsslapd-securePort' => 636

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -198,11 +198,8 @@ describe 'ds389::instance', type: :define do
                   {
                     'cn=config' => {
                       'nsslapd-require-secure-binds' => 'on'
-                    },
-                    'cn=encryption,cn=config' => {
-                      'nsSSL3Ciphers' => %r{AES_256}
                     }
-                  },
+                  }
                 )
                 .with_token(%r{^\S{32}$})
                 .with_service_group('dirsrv')


### PR DESCRIPTION
* Fixed:
  * Changed nsSSLClientAuth to `allowed` from `requried` to match the
    suggestions in the vendor documentation
  * Changed nsslapd-minssf to `128` from `256` to alleviate the GnuTLS cipher
    ordering issue. The 389-DS project does not see this as a 389-DS issue and
    the cipher order is hard-coded in GnuTLS but this is a reasonable default
  * Removed the nsSSL3Ciphers list since it is no longer required with the
    updated `nsslapd-minssf` setting.

SIMP-9737 #comment Loosened TLS defaults per vendor documentation