### PR TITLE
Update deps to use puppet/systemd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,12 @@
 .idea/
 dist
 /pkg
-/spec/fixtures
+# Read everything in fixtures
+/spec/fixtures/*
+# Un-ignore hieradata
+!/spec/fixtures/hieradata/*
+# Except this one, which is auto-generated
+/spec/fixtures/hieradata/hiera.yaml
 /spec/rp_env
 /.rspec_system
 /.vagrant

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jun 03 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.2.0
+- Update from camptocamp/systemd to puppet/systemd
+
 * Wed Sep 22 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.2
 - Ensure that the instances can load multiple CA certificates
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ds389",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "author": "SIMP Team",
   "summary": "Management of 389 Directory Server",
   "license": "Apache-2.0",
@@ -9,8 +9,8 @@
   "issues_url": "https://simp-project.atlassian.net",
   "dependencies": [
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.7.0 < 3.0.0"
+      "name": "puppet/systemd",
+      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "simp/simplib",

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -17,7 +17,8 @@ describe 'ds389::install' do
 
       context "with #{os}" do
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_package('389-ds-base').with_ensure('present') }
+        # Work around for https://github.com/puppetlabs/puppetlabs-stdlib/pull/1196
+        it { is_expected.to contain_package('389-ds-base').with_ensure(/\A(present|installed)\Z/) }
         it { is_expected.not_to contain_package('389-admin') }
         it { is_expected.not_to contain_package('389-admin-console') }
         it { is_expected.not_to contain_package('389-ds-console') }


### PR DESCRIPTION
This patch updates from camptocamp/systemd 2.x to puppet/systemd 3.x

This bump is driven by simp/simp-core#829